### PR TITLE
add copy_user command

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -19,9 +19,11 @@ ruff = "*"
 mypy = "*"
 types-requests = "*"
 types-tabulate = "*"
+pytest-mock = "*"
 
 [requires]
 python_version = "3.12"
 
 [scripts]
-copy_roles = "python -c \"from copyroles.cli import main; main()\""
+copy_roles = "python -c \"from copyroles.cli import copy_roles; copy_roles()\""
+copy_user = "python -c \"from copyroles.cli import copy_user; copy_user()\""

--- a/Pipfile
+++ b/Pipfile
@@ -25,5 +25,4 @@ pytest-mock = "*"
 python_version = "3.12"
 
 [scripts]
-copy_roles = "python -c \"from copyroles.cli import copy_roles; copy_roles()\""
-copy_user = "python -c \"from copyroles.cli import copy_user; copy_user()\""
+copy = "python -c \"from copyroles.cli import cli; cli()\""

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "af7f4ec0843f66f46b091e3a118e641c01e34d24f0f1a4cd3be257452aac4c84"
+            "sha256": "edb634dd9579d319ce81b3f0cc5bbf370191f3ae0735b83fd7490d29b6b4ec03"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -553,6 +553,15 @@
             "index": "pypi",
             "markers": "python_version >= '3.8'",
             "version": "==8.3.4"
+        },
+        "pytest-mock": {
+            "hashes": [
+                "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f",
+                "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==3.14.0"
         },
         "pyyaml": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # copyroles
 
-- Copies all alma roles from one user to another.
-- Any existing roles of the destination user are overwritten.
+Utilities for copying alma roles and users
 
 ## Required ENV
 ```shell
-ALMA_API_KEY=# an Alma API key with `user` read/write permissions and `conf` read permissions
+PROD_ALMA_API_KEY=# an Alma API key for the Alma `production` environemnt with `user` read/write permissions and `conf` read permissions
+SANDBOX_ALMA_API_KEY=# an Alma API key for the Alma `sandbox` environemnt with `user` read/write permissions and `conf` read permissions
 ```
 ## To run
 
@@ -13,6 +13,14 @@ ALMA_API_KEY=# an Alma API key with `user` read/write permissions and `conf` rea
     
     `make install`
 
-- Run the script from the virtual environment, passing in the primary ID's of the source and target users as commandline arguments
+- Run the command from the virtual environment, passing in the required parameters 
+    - copy_roles: 
+        - copy alma rules from one user to another in the same alma environment
+        -  the roles of the target users will be completely overwritten
 
-    `pipenv run copy_roles [primary_id_of_user_to_copy_from] [primary_id_of_user_to_copy_to]`
+         `pipenv run copy_roles [primary_id_of_source_user] [primary_id_of_target_user] --environment [prod|sandbox]`
+    - copy_user: 
+        - Copy a user from Production to Sandbox
+
+         `pipenv run copy_user = [primary_id_of_source_user]`
+    

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ SANDBOX_ALMA_API_KEY=# an Alma API key for the Alma `sandbox` environemnt with `
         - copy alma rules from one user to another in the same alma environment
         -  the roles of the target users will be completely overwritten
 
-         `pipenv run copy_roles [primary_id_of_source_user] [primary_id_of_target_user] --environment [prod|sandbox]`
+         `pipenv run copy copy-roles [primary_id_of_source_user] [primary_id_of_target_user] --environment [prod|sandbox]`
     - copy_user: 
         - Copy a user from Production to Sandbox
 
-         `pipenv run copy_user = [primary_id_of_source_user]`
+         `pipenv run copy copy-user = [primary_id_of_source_user]`
     

--- a/README.md
+++ b/README.md
@@ -7,20 +7,25 @@ Utilities for copying alma roles and users
 PROD_ALMA_API_KEY=# an Alma API key for the Alma `production` environemnt with `user` read/write permissions and `conf` read permissions
 SANDBOX_ALMA_API_KEY=# an Alma API key for the Alma `sandbox` environemnt with `user` read/write permissions and `conf` read permissions
 ```
+## Optional ENV
+```shell
+ALMA_API_ENDPOINT=# The base URL for the Alma API. Default is https://api-na.hosted.exlibrisgroup.com/almaws/v1/
+```
 ## To run
 
 - Create a virtual environment and install dependencies
     
     `make install`
 
-- Run the command from the virtual environment, passing in the required parameters 
-    - copy_roles: 
+- Run the `copy` command from the virtual environment, passing in the required parameters 
+    - copy-roles: 
         - copy alma rules from one user to another in the same alma environment
-        -  the roles of the target users will be completely overwritten
+        - the roles of the target user will be completely overwritten
 
          `pipenv run copy copy-roles [primary_id_of_source_user] [primary_id_of_target_user] --environment [prod|sandbox]`
-    - copy_user: 
+    - copy-user: 
         - Copy a user from Production to Sandbox
 
-         `pipenv run copy copy-user = [primary_id_of_source_user]`
+         `pipenv run copy copy-user [primary_id_of_source_user]`
     
+ 

--- a/copyroles/alma.py
+++ b/copyroles/alma.py
@@ -7,7 +7,7 @@ class AlmaClient:
     def __init__(
         self,
         api_key: str,
-        base_url: str = "https://api-na.hosted.exlibrisgroup.com/almaws/v1/",
+        base_url: str,
     ) -> None:
         self.base_url = base_url
         self.api_key = api_key

--- a/copyroles/cli.py
+++ b/copyroles/cli.py
@@ -7,54 +7,47 @@ from tabulate import tabulate
 from copyroles.alma import AlmaClient
 
 
-@click.command()
+@click.group()
+def cli() -> None:
+    """CLI for CopyRoles."""
+
+
+@cli.command()
 @click.argument("source_username", type=str)
 @click.argument("target_username", type=str)
 @click.option(
-    "--source-env",
+    "-e",
+    "--environment",
     type=click.Choice(["prod", "sandbox"], case_sensitive=False),
     required=True,
-    help="Environment of the source user (prod or sandbox).",
+    help="The Alma environment(prod or sandbox) within which the roles will be copied.",
 )
-@click.option(
-    "--target-env",
-    type=click.Choice(["prod", "sandbox"], case_sensitive=False),
-    required=True,
-    help="Environment of the target user (prod or sandbox).",
-)
-def main(
-    source_username: str, target_username: str, source_env: str, target_env: str
+def copy_roles(
+    source_username: str,
+    target_username: str,
+    environment: str,
 ) -> None:
-    if source_env == "sandbox" and target_env == "prod":
-        message = "Cannot copy roles from sandbox to prod environment."
-        raise click.UsageError(message)
     alma_api_keys = {}
     alma_api_keys["prod"] = os.environ["PROD_ALMA_API_KEY"]
     alma_api_keys["sandbox"] = os.environ["SANDBOX_ALMA_API_KEY"]
-    try:
-        source_alma_client = AlmaClient(alma_api_keys[source_env])
-        target_alma_client = AlmaClient(alma_api_keys[target_env])
-    except KeyError as e:
-        click.echo(f"Error creating alma client: {e}")
-        return
+    alma_client = AlmaClient(alma_api_keys[environment])
     job_summary = (
         f"Source: \033[1m{source_username.upper()}\033[0m - "
-        f"\033[1m{target_alma_client.alma_environment.upper()}\033[0m\n"
+        f"\033[1m{alma_client.alma_environment.upper()}\033[0m\n"
         f"Target: \033[1m{target_username.upper()}\033[0m - "
-        f"\033[1m{target_alma_client.alma_environment.upper()}\033[0m\n"
+        f"\033[1m{alma_client.alma_environment.upper()}\033[0m\n"
     )
     click.echo("\n-- Copy Alma Roles --\n" + job_summary)
 
     if click.confirm("Continue and review roles?", default=False, abort=False):
         try:
-            source_user = source_alma_client.get_alma_user(source_username)
-            target_user = target_alma_client.get_alma_user(target_username)
-            source_roles: list = source_user["user_role"]
+            source_user = alma_client.get_alma_user(source_username)
+            target_user = alma_client.get_alma_user(target_username)
         except HTTPError as e:
-            click.echo(f"Error getting users: {e}")
-            return
+            error_message = f"Could not get user - {e.response.text}"
+            raise click.ClickException(error_message) from e
         if click.confirm("review roles?"):
-            click.echo(print_user_roles(source_roles))
+            click.echo(print_user_roles(source_user["user_role"]))
         do_copy = click.prompt(
             "\nCopy these Alma roles?\n"
             + job_summary
@@ -63,10 +56,62 @@ def main(
             show_choices=False,
         )
         if do_copy == "copy-roles":
-            target_alma_client.update_alma_roles(source_roles, target_user)
-            click.echo("Roles copied.")
+            try:
+                alma_client.update_alma_roles(source_user["user_role"], target_user)
+                click.echo("Roles copied.")
+            except HTTPError as e:
+                error_message = f"Could not update roles - {e.response.text}"
+                raise click.ClickException(error_message) from e
         else:
             click.echo("Copy operation cancelled.")
+
+
+@click.argument("username", type=str)
+@click.option(
+    "--source-env",
+    type=click.Choice(["prod", "sandbox"], case_sensitive=False),
+    required=True,
+    default="prod",
+    help="Environment of the source user (prod or sandbox).",
+)
+@click.option(
+    "--target-env",
+    type=click.Choice(["prod", "sandbox"], case_sensitive=False),
+    required=True,
+    default="sandbox",
+    help="Environment of the target user (prod or sandbox).",
+)
+@cli.command()
+def copy_user(username: str, source_env: str, target_env: str) -> None:
+    if source_env == "sandbox" and target_env == "prod":
+        message = "Cannot copy users from sandbox to prod environment."
+        raise click.UsageError(message)
+    click.echo("copy user")
+    alma_api_keys = {}
+    alma_api_keys["prod"] = os.environ["PROD_ALMA_API_KEY"]
+    alma_api_keys["sandbox"] = os.environ["SANDBOX_ALMA_API_KEY"]
+    source_alma_client = AlmaClient(alma_api_keys[source_env])
+    target_alma_client = AlmaClient(alma_api_keys[target_env])
+    job_summary = (
+        f"Source: \033[1m{username.upper()}\033[0m - "
+        f"\033[1m{source_alma_client.alma_environment.upper()}\033[0m\n"
+        f"Target: \033[1m{username.upper()}\033[0m - "
+        f"\033[1m{target_alma_client.alma_environment.upper()}\033[0m\n"
+    )
+    click.echo("\n-- Copy Alma User --\n" + job_summary)
+
+    if click.confirm("Continue?", default=False, abort=False):
+        try:
+            source_user = source_alma_client.get_alma_user(username)
+        except HTTPError as e:
+            error_message = f"Could not get user - {e.response.text}"
+            raise click.ClickException(error_message) from e
+        try:
+            target_alma_client.create_alma_user(source_user)
+            click.echo("User copied.")
+        except HTTPError as e:
+            error_message = f"Could not create user - {e.response.text}"
+            raise click.ClickException(error_message) from e
 
 
 def print_user_roles(roles: list) -> str:

--- a/copyroles/cli.py
+++ b/copyroles/cli.py
@@ -1,15 +1,21 @@
-import os
-
 import click
 from requests.exceptions import HTTPError
 from tabulate import tabulate
 
 from copyroles.alma import AlmaClient
+from copyroles.config import Config
+
+# instantiate a Config object
+CONFIG = Config()
 
 
 @click.group()
 def cli() -> None:
     """CLI for CopyRoles."""
+    try:
+        CONFIG.check_required_env_vars()
+    except OSError as e:
+        raise click.ClickException(str(e)) from e
 
 
 @cli.command()
@@ -28,9 +34,11 @@ def copy_roles(
     environment: str,
 ) -> None:
     alma_api_keys = {}
-    alma_api_keys["prod"] = os.environ["PROD_ALMA_API_KEY"]
-    alma_api_keys["sandbox"] = os.environ["SANDBOX_ALMA_API_KEY"]
-    alma_client = AlmaClient(alma_api_keys[environment])
+    alma_api_keys["prod"] = CONFIG.prod_alma_api_key
+    alma_api_keys["sandbox"] = CONFIG.sandbox_alma_api_key
+    alma_client = AlmaClient(
+        alma_api_keys[environment], base_url=CONFIG.alma_api_endpoint
+    )
     job_summary = (
         f"Source: \033[1m{source_username.upper()}\033[0m - "
         f"\033[1m{alma_client.alma_environment.upper()}\033[0m\n"
@@ -88,10 +96,14 @@ def copy_user(username: str, source_env: str, target_env: str) -> None:
         raise click.UsageError(message)
     click.echo("copy user")
     alma_api_keys = {}
-    alma_api_keys["prod"] = os.environ["PROD_ALMA_API_KEY"]
-    alma_api_keys["sandbox"] = os.environ["SANDBOX_ALMA_API_KEY"]
-    source_alma_client = AlmaClient(alma_api_keys[source_env])
-    target_alma_client = AlmaClient(alma_api_keys[target_env])
+    alma_api_keys["prod"] = CONFIG.prod_alma_api_key
+    alma_api_keys["sandbox"] = CONFIG.sandbox_alma_api_key
+    source_alma_client = AlmaClient(
+        alma_api_keys[source_env], base_url=CONFIG.alma_api_endpoint
+    )
+    target_alma_client = AlmaClient(
+        alma_api_keys[target_env], base_url=CONFIG.alma_api_endpoint
+    )
     job_summary = (
         f"Source: \033[1m{username.upper()}\033[0m - "
         f"\033[1m{source_alma_client.alma_environment.upper()}\033[0m\n"

--- a/copyroles/cli.py
+++ b/copyroles/cli.py
@@ -33,11 +33,8 @@ def copy_roles(
     target_username: str,
     environment: str,
 ) -> None:
-    alma_api_keys = {}
-    alma_api_keys["prod"] = CONFIG.prod_alma_api_key
-    alma_api_keys["sandbox"] = CONFIG.sandbox_alma_api_key
     alma_client = AlmaClient(
-        alma_api_keys[environment], base_url=CONFIG.alma_api_endpoint
+        CONFIG.get_alma_api_key(environment), base_url=CONFIG.alma_api_endpoint
     )
     job_summary = (
         f"Source: \033[1m{source_username.upper()}\033[0m - "
@@ -95,14 +92,12 @@ def copy_user(username: str, source_env: str, target_env: str) -> None:
         message = "Cannot copy users from sandbox to prod environment."
         raise click.UsageError(message)
     click.echo("copy user")
-    alma_api_keys = {}
-    alma_api_keys["prod"] = CONFIG.prod_alma_api_key
-    alma_api_keys["sandbox"] = CONFIG.sandbox_alma_api_key
+
     source_alma_client = AlmaClient(
-        alma_api_keys[source_env], base_url=CONFIG.alma_api_endpoint
+        CONFIG.get_alma_api_key(source_env), base_url=CONFIG.alma_api_endpoint
     )
     target_alma_client = AlmaClient(
-        alma_api_keys[target_env], base_url=CONFIG.alma_api_endpoint
+        CONFIG.get_alma_api_key(target_env), base_url=CONFIG.alma_api_endpoint
     )
     job_summary = (
         f"Source: \033[1m{username.upper()}\033[0m - "

--- a/copyroles/config.py
+++ b/copyroles/config.py
@@ -1,0 +1,38 @@
+import os
+from collections.abc import Iterable
+
+
+class Config:
+    REQUIRED_ENV_VARS: Iterable[str] = [
+        "PROD_ALMA_API_KEY",
+        "SANDBOX_ALMA_API_KEY",
+    ]
+
+    def check_required_env_vars(self) -> None:
+        """Method to raise exception if required env vars not set."""
+        missing_vars = [var for var in self.REQUIRED_ENV_VARS if not os.getenv(var)]
+        if missing_vars:
+            message = f"Missing required environment variables: {', '.join(missing_vars)}"
+            raise OSError(message)
+
+    @property
+    def alma_api_endpoint(self) -> str:
+        return os.getenv(
+            "ALMA_API_ENDPOINT", "https://api-na.hosted.exlibrisgroup.com/almaws/v1/"
+        )
+
+    @property
+    def prod_alma_api_key(self) -> str:
+        value = os.getenv("PROD_ALMA_API_KEY")
+        if not value:
+            error_message = "Env var 'PROD_ALMA_API_KEY' must be defined"
+            raise OSError(error_message)
+        return value
+
+    @property
+    def sandbox_alma_api_key(self) -> str:
+        value = os.getenv("SANDBOX_ALMA_API_KEY")
+        if not value:
+            error_message = "Env var 'SANDBOX_ALMA_API_KEY' must be defined"
+            raise OSError(error_message)
+        return value

--- a/copyroles/config.py
+++ b/copyroles/config.py
@@ -15,6 +15,14 @@ class Config:
             message = f"Missing required environment variables: {', '.join(missing_vars)}"
             raise OSError(message)
 
+    def get_alma_api_key(self, environment: str) -> str:
+        if environment == "sandbox":
+            return self.sandbox_alma_api_key
+        if environment == "prod":
+            return self.prod_alma_api_key
+        error_message = f"Alma environment '{environment}' not recognized."
+        raise ValueError(error_message)
+
     @property
     def alma_api_endpoint(self) -> str:
         return os.getenv(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _test_env(monkeypatch):
+    monkeypatch.setenv("PROD_ALMA_API_KEY", "fake-key")
+    monkeypatch.setenv("SANDBOX_ALMA_API_KEY", "fake-key")

--- a/tests/test_alma.py
+++ b/tests/test_alma.py
@@ -6,9 +6,16 @@ import requests_mock
 from copyroles.alma import AlmaClient
 
 
+@pytest.fixture
+def test_alma_client():
+    api_key = "test_api_key"
+    base_url = "https://example.com/"
+    return AlmaClient(api_key, base_url)
+
+
 def test_alma_client_initialization():
     api_key = "test_api_key"
-    base_url = "https://example.com/almaws/v1/"
+    base_url = "https://example.com/"
     client = AlmaClient(api_key, base_url)
 
     assert client.api_key == api_key
@@ -18,20 +25,8 @@ def test_alma_client_initialization():
     assert client.headers["Content-Type"] == "application/json"
 
 
-def test_alma_client_default_base_url():
-    api_key = "test_api_key"
-    client = AlmaClient(api_key)
-
-    assert client.api_key == api_key
-    assert client.base_url == "https://api-na.hosted.exlibrisgroup.com/almaws/v1/"
-    assert client.headers["Authorization"] == f"apikey {api_key}"
-    assert client.headers["Accept"] == "application/json"
-    assert client.headers["Content-Type"] == "application/json"
-
-
-def test_get_alma_user():
-    api_key = "test_api_key"
-    client = AlmaClient(api_key)
+def test_get_alma_user(test_alma_client):
+    client = test_alma_client
     primary_id = "kerb@mit.edu"
     user_data = {"primary_id": primary_id, "user_role": [{"role": "test"}]}
     with requests_mock.Mocker() as m:
@@ -40,9 +35,8 @@ def test_get_alma_user():
         assert response == user_data
 
 
-def test_update_alma_roles():
-    api_key = "test_api_key"
-    client = AlmaClient(api_key)
+def test_update_alma_roles(test_alma_client):
+    client = test_alma_client
     primary_id = "kerb@mit.edu"
     new_roles = [{"role": "test"}]
     user_to_update = {"primary_id": primary_id}
@@ -54,18 +48,16 @@ def test_update_alma_roles():
         assert m.last_request.json() == expected_payload
 
 
-def test_create_alma_user(user_record):
-    api_key = "test_api_key"
-    client = AlmaClient(api_key)
+def test_create_alma_user(user_record, test_alma_client):
+    client = test_alma_client
     with requests_mock.Mocker() as m:
         m.post(f"{client.base_url}users/")
         client.create_alma_user(user_record)
         assert m.last_request.json() == user_record
 
 
-def test_alma_environment():
-    api_key = "test_api_key"
-    client = AlmaClient(api_key)
+def test_alma_environment(test_alma_client):
+    client = test_alma_client
     environment_data = {"environment_type": "production"}
     with requests_mock.Mocker() as m:
         m.get(f"{client.base_url}conf/general", json=environment_data)

--- a/tests/test_alma.py
+++ b/tests/test_alma.py
@@ -13,10 +13,10 @@ def test_alma_client():
     return AlmaClient(api_key, base_url)
 
 
-def test_alma_client_initialization():
+def test_alma_client_initialization(test_alma_client):
     api_key = "test_api_key"
     base_url = "https://example.com/"
-    client = AlmaClient(api_key, base_url)
+    client = test_alma_client
 
     assert client.api_key == api_key
     assert client.base_url == base_url

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,13 @@
-from copyroles.cli import print_user_roles
+import pytest
+from click.testing import CliRunner
+from requests.exceptions import HTTPError
+
+from copyroles.cli import cli, print_user_roles
 
 
-def test_print_user_roles():
-    roles = [
+@pytest.fixture
+def roles():
+    return [
         {
             "status": {"desc": "ACTIVE"},
             "role_type": {"desc": "Admin"},
@@ -14,6 +19,38 @@ def test_print_user_roles():
             "scope": {"desc": "Library"},
         },
     ]
+
+
+@pytest.fixture
+def mock_alma_client(mocker):
+    mocked_alma_client_class = mocker.patch("copyroles.cli.AlmaClient")
+    mocked_client_instance = mocked_alma_client_class.return_value
+
+    mocked_client_instance.alma_environment = "sandbox"
+    mocked_client_instance.get_alma_user.side_effect = [
+        {"primary_id": "sourceuser@example.com", "user_role": [{"role": "test"}]},
+        {"primary_id": "targetuser@example.com", "user_role": []},
+    ]
+    mocked_client_instance.update_alma_roles.return_value = None
+    return mocked_client_instance
+
+
+@pytest.fixture
+def mock_print_roles(mocker):
+    return mocker.patch("copyroles.cli.print_user_roles", return_value="test")
+
+
+@pytest.fixture
+def cli_runner():
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def mock_env(monkeypatch):
+    monkeypatch.setenv("SANDBOX_ALMA_API_KEY", "test_sandbox_api_key")
+
+
+def test_print_user_roles(roles):
     expected = (
         "status    role_type    scope\n"
         "--------  -----------  -----------\n"
@@ -21,3 +58,116 @@ def test_print_user_roles():
         "INACTIVE  User         Library"
     )
     assert print_user_roles(roles) == expected
+
+
+def test_copy_user_sandbox_to_prod_raises_error(cli_runner):
+    usage_error_code = 2
+
+    result = cli_runner.invoke(
+        cli, ["copy-user", "--source-env", "sandbox", "--target-env", "prod", "testuser"]
+    )
+    assert result.exit_code == usage_error_code
+    assert "Cannot copy users from sandbox to prod environment." in result.output
+
+
+def test_copy_roles_success(mock_alma_client, mock_print_roles, cli_runner):
+    result = cli_runner.invoke(
+        cli,
+        [
+            "copy-roles",
+            "-e",
+            "sandbox",
+            "sourceuser@example.com",
+            "targetuser@example.com",
+        ],
+        input="y\ny\ncopy-roles\n",
+    )
+    mock_print_roles.assert_called_once()
+    mock_alma_client.get_alma_user.assert_any_call("sourceuser@example.com")
+    mock_alma_client.get_alma_user.assert_any_call("targetuser@example.com")
+    mock_alma_client.update_alma_roles.assert_called_once()
+    assert "Roles copied" in result.output
+    assert result.exit_code == 0
+
+
+def test_copy_roles_get_user_error(mocker, mock_alma_client, cli_runner):
+    mock_response = mocker.MagicMock()
+    mock_response.text = "foo"
+    mock_alma_client.get_alma_user.side_effect = HTTPError(response=mock_response)
+    result = cli_runner.invoke(
+        cli,
+        ["copy-roles", "-e", "sandbox", "sourceuser", "targetuser"],
+        input="y\ny\n",
+    )
+    assert result.exit_code == 1
+    assert "Error: Could not get user - foo" in result.output
+
+
+def test_copy_roles_update_roles_error(
+    mock_print_roles, mocker, mock_alma_client, cli_runner
+):
+    mock_response = mocker.MagicMock()
+    mock_response.text = "foo"
+    mock_alma_client.update_alma_roles.side_effect = HTTPError(response=mock_response)
+    result = cli_runner.invoke(
+        cli,
+        ["copy-roles", "-e", "sandbox", "sourceuser", "targetuser"],
+        input="y\ny\ncopy-roles\n",
+    )
+    assert result.exit_code == 1
+    assert "Error: Could not update roles - foo" in result.output
+
+
+def test_copy_roles_cancelled(
+    mock_print_roles, mocker, mock_env, mock_alma_client, cli_runner
+):
+    mock_response = mocker.MagicMock()
+    mock_response.text = "foo"
+    mock_alma_client.update_alma_roles.side_effect = HTTPError(response=mock_response)
+    result = cli_runner.invoke(
+        cli,
+        ["copy-roles", "-e", "sandbox", "sourceuser", "targetuser"],
+        input="y\ny\nfoo\n",
+    )
+    assert result.exit_code == 0
+    assert "Copy operation cancelled" in result.output
+
+
+def test_copy_user_default_success(mocker, mock_alma_client, cli_runner):
+    """Test copy-user CLI command."""
+    mock_click_echo = mocker.patch("click.echo")
+    result = cli_runner.invoke(
+        cli,
+        ["copy-user", "username"],
+        input="y\ny\ncopy-user\n",
+    )
+
+    mock_alma_client.get_alma_user.assert_called_once_with("username")
+    mock_click_echo.assert_called_with("User copied.")
+    assert result.exit_code == 0
+
+
+def test_copy_user_get_user_error(mocker, mock_alma_client, cli_runner):
+    mock_response = mocker.MagicMock()
+    mock_response.text = "foo"
+    mock_alma_client.get_alma_user.side_effect = HTTPError(response=mock_response)
+    result = cli_runner.invoke(
+        cli,
+        ["copy-user", "username"],
+        input="y\ny\n",
+    )
+    assert result.exit_code == 1
+    assert "Error: Could not get user - foo" in result.output
+
+
+def test_copy_user_create_user_error(mocker, mock_alma_client, cli_runner):
+    mock_response = mocker.MagicMock()
+    mock_response.text = "foo"
+    mock_alma_client.create_alma_user.side_effect = HTTPError(response=mock_response)
+    result = cli_runner.invoke(
+        cli,
+        ["copy-user", "username"],
+        input="y\ny\n",
+    )
+    assert result.exit_code == 1
+    assert "Error: Could not create user - foo" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,6 +50,16 @@ def mock_env(monkeypatch):
     monkeypatch.setenv("SANDBOX_ALMA_API_KEY", "test_sandbox_api_key")
 
 
+def test_cli_with_missing_env_vars(cli_runner, monkeypatch):
+    monkeypatch.delenv("SANDBOX_ALMA_API_KEY")
+    result = cli_runner.invoke(
+        cli,
+        ["copy-roles", "-e", "sandbox", "sourceuser", "targetuser"],
+    )
+    assert result.exit_code == 1
+    assert "Missing required environment variables" in result.output
+
+
 def test_print_user_roles(roles):
     expected = (
         "status    role_type    scope\n"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,26 @@
+import pytest
+
+from copyroles.config import Config
+
+
+@pytest.fixture
+def config_instance():
+    return Config()
+
+
+def test_prod_alma_api_key_raises_error(monkeypatch, config_instance):
+    monkeypatch.delenv("PROD_ALMA_API_KEY")
+    with pytest.raises(OSError, match="Env var 'PROD_ALMA_API_KEY' must be defined"):
+        _ = config_instance.prod_alma_api_key
+
+
+def test_sandbox_alma_api_key_raises_error(monkeypatch, config_instance):
+    monkeypatch.delenv("SANDBOX_ALMA_API_KEY")
+    with pytest.raises(OSError, match="Env var 'SANDBOX_ALMA_API_KEY' must be defined"):
+        _ = config_instance.sandbox_alma_api_key
+
+
+def test_check_required_env_vars(monkeypatch, config_instance):
+    monkeypatch.delenv("SANDBOX_ALMA_API_KEY")
+    with pytest.raises(OSError, match="Missing required environment variables:"):
+        config_instance.check_required_env_vars()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,3 +24,21 @@ def test_check_required_env_vars(monkeypatch, config_instance):
     monkeypatch.delenv("SANDBOX_ALMA_API_KEY")
     with pytest.raises(OSError, match="Missing required environment variables:"):
         config_instance.check_required_env_vars()
+
+
+def test_get_alma_api_key(monkeypatch, config_instance):
+    monkeypatch.setenv("SANDBOX_ALMA_API_KEY", "test_sandbox_key")
+    monkeypatch.setenv("PROD_ALMA_API_KEY", "test_prod_key")
+
+    assert config_instance.get_alma_api_key("sandbox") == "test_sandbox_key"
+    assert config_instance.get_alma_api_key("prod") == "test_prod_key"
+
+
+def test_get_alma_api_key_invalid_env(monkeypatch, config_instance):
+    monkeypatch.setenv("SANDBOX_ALMA_API_KEY", "test_sandbox_key")
+    monkeypatch.setenv("PROD_ALMA_API_KEY", "test_prod_key")
+
+    with pytest.raises(
+        ValueError, match="Alma environment 'invalid_env' not recognized."
+    ):
+        config_instance.get_alma_api_key("invalid_env")


### PR DESCRIPTION
### Why these changes are being introduced
We need to add a click command for copying a user record from Production Alma to Sandbox Alma. This additional functionality is useful when new staff accounts are added to production and we need to give those staff the same permissions in Alma Sandbox. 

We need to add unit tests for the CLI commands. Tests are good.

### How this addresses that need
adds a new `copy_user` command to click and a click group to wrap both commands
adds unit tests for the CLI commands covering both success and error paths
updates readme to include instructions for running the new command

### Side effects of this change

pytest-mock was added as a dependency

### Relevant ticket(s)

* https://mitlibraries.atlassian.net/browse/ENSY-230
